### PR TITLE
Normalise paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { resolve, relative } from 'path'
 import colors from 'picocolors'
 import picomatch from 'picomatch'
-import type { PluginOption, ViteDevServer } from 'vite'
+import { normalizePath, PluginOption, ViteDevServer } from 'vite'
 
 /**
  * Configuration for the watched paths.
@@ -46,7 +46,7 @@ export default (paths: string | string[], config: Config = {}): PluginOption => 
   configureServer ({ watcher, ws, config: { logger } }: ViteDevServer) {
     const { root = process.cwd(), log = true, always = true, delay = 0 } = config
 
-    const files = Array.from(paths).map(path => resolve(root, path))
+    const files = Array.from(paths).map(path => resolve(root, path)).map(normalizePath)
     const shouldReload = picomatch(files)
     const checkReload = (path: string) => {
       if (shouldReload(path)) {


### PR DESCRIPTION
(hopefully) Fixes #6

My understanding of the problem is that I believe the `path.resolve` function is converting POSIX to windows.

so specifying...

```js
FullReload(['path/to/files/**'])
```

results in `path\\to\\files\\**`.

This PR pipes all paths through Vite's `normalizePath` function. I believe [this is the recommended way of doing things](https://vitejs.dev/guide/api-plugin.html#path-normalization):

![Screen Shot 2022-07-21 at 1 06 53 pm](https://user-images.githubusercontent.com/24803032/180121309-f3ab7d67-6016-4f94-a654-4bca200e97fd.png)


This function is available in Vite 2 and Vite 3.

> **Warning**: I do not have a windows machine to verify the bug, but also to verify this fix. This solutions needs some real-world testing done.