### PR TITLE
fix: "Conflicting peer dependency"

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "picomatch": "^2.3.1"
   },
   "peerDependencies": {
-    "vite": "2"
+    "vite": "^2 || ^3"
   },
   "devDependencies": {
     "@antfu/eslint-config": "*",


### PR DESCRIPTION
NPM complains about "Conflicting peer dependency" when using your package:

```sh
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: vite-plugin-full-reload@1.0.2
npm WARN Found: vite@3.0.2
npm WARN node_modules/vite
npm WARN   dev vite@"^3.0.0" from the root project
npm WARN   2 more (@defstudio/vite-livewire-plugin, laravel-vite-plugin)
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer vite@"2" from vite-plugin-full-reload@1.0.2
npm WARN node_modules/vite-plugin-full-reload
npm WARN   vite-plugin-full-reload@"^1.0.0" from @defstudio/vite-livewire-plugin@0.2.0
npm WARN   node_modules/@defstudio/vite-livewire-plugin
npm WARN   1 more (laravel-vite-plugin)
npm WARN 
npm WARN Conflicting peer dependency: vite@2.9.14
npm WARN node_modules/vite
npm WARN   peer vite@"2" from vite-plugin-full-reload@1.0.2
npm WARN   node_modules/vite-plugin-full-reload
npm WARN     vite-plugin-full-reload@"^1.0.0" from @defstudio/vite-livewire-plugin@0.2.0
npm WARN     node_modules/@defstudio/vite-livewire-plugin
npm WARN     1 more (laravel-vite-plugin)
```

If you do not want to maintain Vite v2 compatibility, we can remove that from the peer dependencies and just leave v3.