### PR TITLE
feat: add vite 4 as a valid peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "picomatch": "^2.3.1"
   },
   "peerDependencies": {
-    "vite": "^2 || ^3"
+    "vite": "^2 || ^3 || ^4"
   },
   "devDependencies": {
     "@antfu/eslint-config": "*",
@@ -68,7 +68,7 @@
     "semver": "^7.3.7",
     "tsup": "^6.1.3",
     "typescript": "^4.7.4",
-    "vite": "^3",
+    "vite": "^4.0.0",
     "vitest": "^0.21.1"
   },
   "lint-staged": {


### PR DESCRIPTION
Draft until v4 is released. Seems to be working as expected from my testing.

Release is expected tomorrow. You can test against the beta by installing `vite@beta`.