### PR TITLE
[1.x] Differentiate plugin log from Vite log

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ export default (paths: string | string[], config: Config = {}): PluginOption => 
       if (shouldReload(path)) {
         setTimeout(() => ws.send({ type: 'full-reload', path: always ? '*' : path }), delay)
         if (log)
-          logger.info(`${colors.green('page reload')} ${colors.dim(relative(root, path))}`, { clear: true, timestamp: true })
+          logger.info(`${colors.green('full reload')} ${colors.dim(relative(root, path))}`, { clear: true, timestamp: true })
       }
     }
 


### PR DESCRIPTION
Hey @ElMassimo! Got a small proposal here for your consideration.

Currently, when the Full Reload plugin performs a reload it logs the following...

<img width="602" alt="Screen Shot 2023-06-14 at 10 05 15 am" src="https://github.com/ElMassimo/vite-plugin-full-reload/assets/24803032/76a19e88-4fe1-4dbe-8cb2-4b6404174730">

This is great.

If I disable the Full Reload plugin and have a dependency loop, which is very common when using something like Tailwind CSS with template files, Vite will output the following when a dependency in said loop is updated...

<img width="618" alt="Screen Shot 2023-06-14 at 10 08 02 am" src="https://github.com/ElMassimo/vite-plugin-full-reload/assets/24803032/34a05e2b-72a4-4652-91ad-d0c03fcaad65">

When seen in combination it makes it harder debug where the issue came from. Was this reload triggered by Full Reload or by Vite? I would like to propose that the console output for this plugin differentiate itself from the logging that Vite itself does.

This is really just a debugging improvement to determine where the issue actually came from.

<img width="608" alt="Screen Shot 2023-06-14 at 10 13 49 am" src="https://github.com/ElMassimo/vite-plugin-full-reload/assets/24803032/7588f760-63eb-4adc-acad-3eeaf1c31c3d">

Thanks again for this fantastic plugin.